### PR TITLE
Updated to guzzlehttp/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "^5.0",
-        "guzzle/guzzle": "3.*"
+        "guzzlehttp/guzzle": "5.3.*"
     },
     "require-dev": {
         "phpspec/phpspec": "2.0.*@dev"

--- a/spec/Spatie/Geocoder/Google/GeocoderSpec.php
+++ b/spec/Spatie/Geocoder/Google/GeocoderSpec.php
@@ -2,7 +2,7 @@
 
 namespace spec\Spatie\Geocoder\Google;
 
-use Guzzle\Service\Client;
+use GuzzleHttp\Client;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Spatie\Geocoder\Geocoder;

--- a/src/Spatie/Geocoder/Google/Geocoder.php
+++ b/src/Spatie/Geocoder/Google/Geocoder.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Geocoder\Google;
 
-use Guzzle\Service\Client;
+use GuzzleHttp\Client;
 use Spatie\Geocoder\Geocoder as GeocoderInterface;
 
 class Geocoder implements GeocoderInterface {
@@ -35,15 +35,13 @@ class Geocoder implements GeocoderInterface {
         if ($query == '') {
             return false;
         }
-
-        $request = $this->client->get('https://maps.googleapis.com/maps/api/geocode/json');
-
-        $request->getQuery()
-            ->set('address', $query)
-            ->set('sensor', 'false');
-
+        
+        $request = $client->createRequest('GET', 'https://maps.googleapis.com/maps/api/geocode/json');
+        $requestQuery = $request->getQuery();
+        $requestQuery->set('address', $query)->set('sensor', 'false');
 
         $response = $request->send();
+        
         if ($response->getStatusCode() != 200) {
             throw new \Exception('could not connect to googleapis.com/maps/api');
         }

--- a/src/Spatie/Geocoder/Google/Geocoder.php
+++ b/src/Spatie/Geocoder/Google/Geocoder.php
@@ -5,7 +5,8 @@ namespace Spatie\Geocoder\Google;
 use GuzzleHttp\Client;
 use Spatie\Geocoder\Geocoder as GeocoderInterface;
 
-class Geocoder implements GeocoderInterface {
+class Geocoder implements GeocoderInterface
+{
 
     /**
      * @var client
@@ -35,33 +36,31 @@ class Geocoder implements GeocoderInterface {
         if ($query == '') {
             return false;
         }
-        
-        $request = $client->createRequest('GET', 'https://maps.googleapis.com/maps/api/geocode/json');
-        $requestQuery = $request->getQuery();
-        $requestQuery->set('address', $query)->set('sensor', 'false');
 
-        $response = $request->send();
-        
+        $request = $this->client->createRequest('GET', 'https://maps.googleapis.com/maps/api/geocode/json');
+        $requestQuery = $request->getQuery();
+        $requestQuery->set('address', $query);
+        $requestQuery->set('sensor', 'false');
+
+        $response = $this->client->send($request);
+
         if ($response->getStatusCode() != 200) {
             throw new \Exception('could not connect to googleapis.com/maps/api');
         }
 
         $fullResponse = $response->json();
 
-
         if (count($fullResponse['results'])) {
             $geocoderResult = [
-                'lat'=> $fullResponse['results'][0]['geometry']['location']['lat'],
-                'lng'=>$fullResponse['results'][0]['geometry']['location']['lng'],
-                'accuracy' => $fullResponse['results'][0]['geometry']['location_type']
+                'lat' => $fullResponse['results'][0]['geometry']['location']['lat'],
+                'lng' => $fullResponse['results'][0]['geometry']['location']['lng'],
+                'accuracy' => $fullResponse['results'][0]['geometry']['location_type'],
             ];
-        }
-        else {
-            $geocoderResult = ['lat'=> 0, 'lng'=> 0, 'accuracy'=> self::RESULT_NOT_FOUND];
+        } else {
+            $geocoderResult = ['lat' => 0, 'lng' => 0, 'accuracy' => self::RESULT_NOT_FOUND];
         }
 
         return $geocoderResult;
     }
 
-
-} 
+}


### PR DESCRIPTION
I get this everytime I do `composer update`:

`Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.`

I exchanged the namespaces, a little bit of code and composer.json. I used guzzlehttp/guzzle in version 5.3. since 6.x is not compatible to PHP 5.4 anymore. It's also still maintained

Hope I did it right, can't exactly test because I'm in a bus with spotty internet connection ;)