### PR TITLE
Remove the sensor param and move the endpoint to a property

### DIFF
--- a/src/Spatie/Geocoder/Google/Geocoder.php
+++ b/src/Spatie/Geocoder/Google/Geocoder.php
@@ -11,8 +11,12 @@ class Geocoder implements GeocoderInterface
     /**
      * @var client
      */
-
     protected $client;
+
+    /**
+     * @var string
+     */
+    protected $endpoint = 'https://maps.googleapis.com/maps/api/geocode/json';
 
     /**
      * @param Client $client
@@ -37,7 +41,7 @@ class Geocoder implements GeocoderInterface
             return false;
         }
 
-        $request = $this->client->createRequest('GET', 'https://maps.googleapis.com/maps/api/geocode/json');
+        $request = $this->client->createRequest('GET', $this->endpoint);
         $requestQuery = $request->getQuery();
         $requestQuery->set('address', $query);
         $requestQuery->set('sensor', 'false');

--- a/src/Spatie/Geocoder/Google/Geocoder.php
+++ b/src/Spatie/Geocoder/Google/Geocoder.php
@@ -44,7 +44,6 @@ class Geocoder implements GeocoderInterface
         $request = $this->client->createRequest('GET', $this->endpoint);
         $requestQuery = $request->getQuery();
         $requestQuery->set('address', $query);
-        $requestQuery->set('sensor', 'false');
 
         $response = $this->client->send($request);
 


### PR DESCRIPTION
The sensor param is no longer useful for Google API.