### PR TITLE
Error Exception

### DIFF
--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -66,6 +66,12 @@ class Geocoder
 
         $geocodingResponse = json_decode($response->getBody());
 
+        // Exception for google api error response
+        if(isset($geocodingResponse->status) && $geocodingResponse->status != "OK" && isset($geocodingResponse->error_message))
+        {
+            throw new Exception($geocodingResponse->status . ' : ' . $geocodingResponse->error_message);
+        }
+
         if (! count($geocodingResponse->results)) {
             return $this->emptyResponse();
         }
@@ -86,6 +92,12 @@ class Geocoder
         }
 
         $reverseGeocodingResponse = json_decode($response->getBody());
+
+        // Exception for google api error response
+        if(isset($reverseGeocodingResponse->status) && $reverseGeocodingResponse->status != "OK" && isset($geocodingResponse->error_message))
+        {
+            throw new Exception($reverseGeocodingResponse->status . ' : ' . $reverseGeocodingResponse->error_message);
+        }
 
         if (! count($reverseGeocodingResponse->results)) {
             return $this->emptyResponse();


### PR DESCRIPTION
Added checks to trigger an exception if Google API triggers an error, previously if the API failed for any reason such as hit todays limits it would respond with "$this->emptyResponse()" however you had no way of knowing what the issue was and why everything was returning empty.

It is up to the user to wrap the calls to "getAddressForCoordinates" and "getCoordinatesForAddress" with a try catch, so that they can perform the required actions on success or API failure. Example below.

```
            // Lookup address to coordinates
            try {
                // Address to coordinates
                $coordinatesLookup = $this->geocoder->getCoordinatesForAddress($postalAddressSearchTerm);
            } catch (\Exception $e) {
                // Send email to alert admin API issue which needs resoling
            }
```