### PR TITLE
If Error Message Present SOMETHING IS WRONG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.phar
 composer.lock
+.idea/

--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -66,6 +66,10 @@ class Geocoder
 
         $geocodingResponse = json_decode($response->getBody());
 
+        if (!empty($geocodingResponse->error_message)) {
+            throw new \Exception($geocodingResponse->status);
+        }
+
         if (! count($geocodingResponse->results)) {
             return $this->emptyResponse();
         }
@@ -86,6 +90,10 @@ class Geocoder
         }
 
         $reverseGeocodingResponse = json_decode($response->getBody());
+
+        if (!empty($reverseGeocodingResponse->error_message)) {
+            throw new \Exception($reverseGeocodingResponse->status);
+        }
 
         if (! count($reverseGeocodingResponse->results)) {
             return $this->emptyResponse();


### PR DESCRIPTION

...so we should throw an `\Exception`!

There's no tests for this, per se, but it does work, see:

```
{
    "message": "OVER_QUERY_LIMIT",
    "exception": "Exception",
    "file": "C:\\laragon\\webroots\\one-calendar\\calendar\\vendor\\spatie\\geocoder\\src\\Geocoder.php",
    "line": 70,
    "trace": [
        {
            "file": "C:\\laragon\\webroots\\one-calendar\\calendar\\vendor\\laravel\\framework\\src\\Illuminate\\Support\\Facades\\Facade.php",
            "line": 221,
            "function": "getCoordinatesForAddress",
            "class": "Spatie\\Geocoder\\Geocoder",
            "type": "->"
        },
```

Addresses #1 - but I cannot re-open that!