### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ $client = new GuzzleHttp\Client();
 
 $geocoder = new Geocoder($client);
 
-$geocoder->getCoordinatesForAddress('Infinite Loop 1, Cupertino', $apiKey);
+$geocoder->setApiKey(config('geocoder.key'));
+
+$geocoder->getCoordinatesForAddress('Infinite Loop 1, Cupertino');
 
 /* 
   This function returns an array with keys


### PR DESCRIPTION
Set API key from config when creating new Geocoder client.

Fixes [#54](https://github.com/spatie/geocoder/issues/54).