### PR TITLE
Laravel 6 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/support": "^5.0",
+        "illuminate/support": "^5.0|^6.0",
         "guzzlehttp/guzzle": "~6.0"
 
     },

--- a/tests/GeocoderTest.php
+++ b/tests/GeocoderTest.php
@@ -56,13 +56,13 @@ class GeocoderTest extends TestCase
     /** @test */
     public function it_can_translate_the_data()
     {
-        $result = $this->geocoder->getCoordinatesForAddress('Roma');
+        $result = $this->geocoder->getCoordinatesForAddress('Roma, Italy');
 
         $this->assertEquals('Rome, Metropolitan City of Rome, Italy', $result['formatted_address']);
 
         $result = $this->geocoder
             ->setLanguage('it')
-            ->getCoordinatesForAddress('Roma');
+            ->getCoordinatesForAddress('Roma, Italy');
 
         $this->assertEquals('Roma RM, Italia', $result['formatted_address']);
     }


### PR DESCRIPTION
Updated composer.json to add support for `illuminate/support` 6.0

Also updated the `it_can_translate_the_data` test to be more specific with `Roma, Italy` as the Geocoder was returning an American address for me, which meant the test was failing.