### PR TITLE
Return Collection of results rather than just the first one.

### DIFF
--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -3,6 +3,7 @@
 namespace Spatie\Geocoder;
 
 use GuzzleHttp\Client;
+use Illuminate\Support\Collection;
 use Spatie\Geocoder\Exceptions\CouldNotGeocode;
 
 class Geocoder
@@ -70,7 +71,7 @@ class Geocoder
         return $this;
     }
 
-    public function getCoordinatesForAddress(string $address): array
+    public function getCoordinatesForAddress(string $address): Collection
     {
         if (empty($address)) {
             return $this->emptyResponse();
@@ -97,7 +98,7 @@ class Geocoder
         return $this->formatResponse($geocodingResponse);
     }
 
-    public function getAddressForCoordinates(float $lat, float $lng): array
+    public function getAddressForCoordinates(float $lat, float $lng): Collection
     {
         $payload = $this->getRequestPayload([
             'latlng' => "$lat,$lng",
@@ -122,17 +123,23 @@ class Geocoder
         return $this->formatResponse($reverseGeocodingResponse);
     }
 
-    protected function formatResponse($response): array
+    protected function formatResponse($response): Collection
     {
-        return [
-            'lat' => $response->results[0]->geometry->location->lat,
-            'lng' => $response->results[0]->geometry->location->lng,
-            'accuracy' => $response->results[0]->geometry->location_type,
-            'formatted_address' => $response->results[0]->formatted_address,
-            'viewport' => $response->results[0]->geometry->viewport,
-            'address_components' => $response->results[0]->address_components,
-            'place_id' => $response->results[0]->place_id,
-        ];
+        $locations = new Collection;
+
+        foreach($response->results as $result) {
+          $locations->push([
+              'lat' => $result->geometry->location->lat,
+              'lng' => $result->geometry->location->lng,
+              'accuracy' => $result->geometry->location_type,
+              'formatted_address' => $result->formatted_address,
+              'viewport' => $result->geometry->viewport,
+              'address_components' => $result->address_components,
+              'place_id' => $result->place_id,
+          ]);
+        }
+
+        return $locations;
     }
 
     protected function getRequestPayload(array $parameters): array
@@ -154,14 +161,14 @@ class Geocoder
         return ['query' => $parameters];
     }
 
-    protected function emptyResponse(): array
+    protected function emptyResponse(): Collection
     {
-        return [
+        return new Collection([
             'lat' => 0,
             'lng' => 0,
             'accuracy' => static::RESULT_NOT_FOUND,
             'formatted_address' => static::RESULT_NOT_FOUND,
             'viewport' => static::RESULT_NOT_FOUND,
-        ];
+        ]);
     }
 }

--- a/tests/GeocoderTest.php
+++ b/tests/GeocoderTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Geocoder\Tests;
 
 use GuzzleHttp\Client;
+use Illuminate\Support\Collection;
 use Spatie\Geocoder\Geocoder;
 
 class GeocoderTest extends TestCase
@@ -34,11 +35,11 @@ class GeocoderTest extends TestCase
     {
         $result = $this->geocoder->getCoordinatesForAddress('Antwerp');
 
-        $this->assertArrayHasKey('lat', $result);
-        $this->assertArrayHasKey('lng', $result);
-        $this->assertArrayHasKey('accuracy', $result);
-        $this->assertArrayHasKey('formatted_address', $result);
-        $this->assertArrayHasKey('viewport', $result);
+        $this->assertArrayHasKey('lat', $result->first());
+        $this->assertArrayHasKey('lng', $result->first());
+        $this->assertArrayHasKey('accuracy', $result->first());
+        $this->assertArrayHasKey('formatted_address', $result->first());
+        $this->assertArrayHasKey('viewport', $result->first());
     }
 
     /** @test */
@@ -58,13 +59,13 @@ class GeocoderTest extends TestCase
     {
         $result = $this->geocoder->getCoordinatesForAddress('Roma, Italy');
 
-        $this->assertEquals('Rome, Metropolitan City of Rome, Italy', $result['formatted_address']);
+        $this->assertEquals('Rome, Metropolitan City of Rome, Italy', $result->first()['formatted_address']);
 
         $result = $this->geocoder
             ->setLanguage('it')
             ->getCoordinatesForAddress('Roma, Italy');
 
-        $this->assertEquals('Roma RM, Italia', $result['formatted_address']);
+        $this->assertEquals('Roma RM, Italia', $result->first()['formatted_address']);
     }
 
     /** @test */
@@ -72,13 +73,13 @@ class GeocoderTest extends TestCase
     {
         $result = $this->geocoder->getAddressForCoordinates(40.714224, -73.961452);
 
-        $this->assertEquals('279 Bedford Ave, Brooklyn, NY 11211, USA', $result['formatted_address']);
+        $this->assertEquals('279 Bedford Ave, Brooklyn, NY 11211, USA', $result->first()['formatted_address']);
 
         $result = $this->geocoder
             ->setLanguage('nl')
             ->getAddressForCoordinates(40.714224, -73.961452);
 
-        $this->assertEquals('279 Bedford Ave, Brooklyn, NY 11211, Verenigde Staten', $result['formatted_address']);
+        $this->assertEquals('279 Bedford Ave, Brooklyn, NY 11211, Verenigde Staten', $result->first()['formatted_address']);
     }
 
     /** @test */
@@ -86,7 +87,7 @@ class GeocoderTest extends TestCase
     {
         $results = $this->geocoder->getCoordinatesForAddress('Infinite Loop 1, Cupertino');
 
-        $this->assertArrayHasKey('address_components', $results);
+        $this->assertArrayHasKey('address_components', $results->first());
     }
 
     /** @test */
@@ -94,7 +95,7 @@ class GeocoderTest extends TestCase
     {
         $results = $this->geocoder->getCoordinatesForAddress('Infinite Loop 1, Cupertino');
 
-        $this->assertArrayHasKey('place_id', $results);
+        $this->assertArrayHasKey('place_id', $results->first());
     }
 
     /** @test */
@@ -104,17 +105,17 @@ class GeocoderTest extends TestCase
             ->setBounds('34.172684,-118.604794|34.236144,-118.500938')
             ->getCoordinatesForAddress('Winnetka');
 
-        $this->assertEquals('Winnetka, Los Angeles, CA, USA', $results['formatted_address']);
+        $this->assertEquals('Winnetka, Los Angeles, CA, USA', $results->first()['formatted_address']);
     }
 
-    protected function emptyResponse(): array
+    protected function emptyResponse(): Collection
     {
-        return [
+        return new Collection([
             'lat' => 0,
             'lng' => 0,
             'accuracy' => Geocoder::RESULT_NOT_FOUND,
             'formatted_address' => Geocoder::RESULT_NOT_FOUND,
             'viewport' => Geocoder::RESULT_NOT_FOUND,
-        ];
+        ]);
     }
 }


### PR DESCRIPTION
I started with this project when I was looking to create a address search drop-down. Rather than selecting the first result, which I found to rarely be the one I needed, I wanted to have a collection or results instead.

This modifies `getCoordinatesForAddress `and `getAddressForCoordinates` to return an Illuminate Collection rather than a single array of the first result. Unfortunately, it does break from the current flow so I'm not sure what would be best practice to allow this option.