### PR TITLE
Return Collection of results rather than just the first one.

### DIFF
--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -183,11 +183,13 @@ class Geocoder
     protected function emptyResponse(): Collection
     {
         return new Collection([
+          [
             'lat' => 0,
             'lng' => 0,
             'accuracy' => static::RESULT_NOT_FOUND,
             'formatted_address' => static::RESULT_NOT_FOUND,
             'viewport' => static::RESULT_NOT_FOUND,
+          ],
         ]);
     }
 }

--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -91,7 +91,7 @@ class Geocoder
         }
 
         if (! count($geocodingResponse->results)) {
-            return $this->emptyResponse()->first();;
+            return $this->emptyResponse()->first();
         }
 
         return $this->formatResponse($geocodingResponse)->first();

--- a/tests/GeocoderTest.php
+++ b/tests/GeocoderTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Geocoder\Tests;
 
 use GuzzleHttp\Client;
 use Spatie\Geocoder\Geocoder;
+use Illuminate\Support\Collection;
 
 class GeocoderTest extends TestCase
 {
@@ -42,9 +43,27 @@ class GeocoderTest extends TestCase
     }
 
     /** @test */
+    public function it_can_geocode_a_city_with_multiple_responses()
+    {
+        $results = $this->geocoder->getAllCoordinatesForAddress('Washingtons');
+
+        $this->assertInstanceOf(Collection::class, $results);
+        $this->assertTrue($results->count() > 1);
+
+        $result = $results->first();
+
+        $this->assertArrayHasKey('lat', $result);
+        $this->assertArrayHasKey('lng', $result);
+        $this->assertArrayHasKey('accuracy', $result);
+        $this->assertArrayHasKey('formatted_address', $result);
+        $this->assertArrayHasKey('viewport', $result);
+    }
+
+    /** @test */
     public function it_should_return_an_empty_response_when_called_with_empty_query()
     {
         $this->assertEquals($this->emptyResponse(), $this->geocoder->getCoordinatesForAddress(''));
+
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,7 +20,7 @@ class TestCase extends PHPUnitTestCase
             return;
         }
 
-        $dotenv = new Dotenv(__DIR__.'/..');
+        $dotenv = Dotenv::create(__DIR__.'/..');
 
         $dotenv->load();
     }


### PR DESCRIPTION
I started with this project when I was looking to create an address search drop-down. Rather than selecting the first result, which I found to rarely be the one I needed, I wanted to have a collection of results instead. I've re-written this so that it doesn't break changes with the original `getCoordinatesForAddress()`.

This pr adds `getAllCoordinatesForAddress()` which will return an `Illuminate\Support\Collection` object containing all of the results.