### PR TITLE
Add Laravel Caching functionality to Geocoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /vendor
 composer.phar
 composer.lock
+
+.env
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -249,11 +249,11 @@ Geocoder::getCoordinatesForAddress('Infinite Loop 1, Cupertino');
 If you are using the package with Laravel, you can also use the Laravel Caching engine.
 Under the hood Cache::remember is used, there are two ways of accessing the cache in Geocoder.
 
-To do this, simply call `getCoordinatesForAddressCached` or `getCoordinatesForAddressCached` to use the cache, even if you have caching disabled in the config.
-Or you can enable caching in the config or via `->setCache(true, ...)` and then simply call `getCoordinatesForAddress` or `getCoordinatesForAddress`.
+To do this, simply call `getAddressForCoordinatesCached` or `getCoordinatesForAddressCached` to use the cache, even if you have caching disabled in the config.
+Or you can enable caching in the config or via `->setCache(true, ...)` and then simply call `getAddressForCoordinates` or `getCoordinatesForAddress`.
 
 If caching has been enabled in the config or via `->setCache(true, ...)` and you wish to not use the cache for a particular lookup,
-simply call `getCoordinatesForAddressUncached` or `getCoordinatesForAddressUncached`.
+simply call `getAddressForCoordinatesUncached` or `getCoordinatesForAddressUncached`.
 
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -2,14 +2,13 @@
     "name": "spatie/geocoder",
     "description": "Geocoding addresses to coordinates",
     "homepage": "https://github.com/spatie/geocoder",
-    "keywords":
-        [
-            "geocode",
-            "map",
-            "coordinate",
-            "location",
-            "laravel"
-        ],
+    "keywords": [
+        "geocode",
+        "map",
+        "coordinate",
+        "location",
+        "laravel"
+    ],
     "license": "MIT",
     "authors": [
         {
@@ -21,9 +20,9 @@
         "php": "^7.2",
         "illuminate/support": "^5.0|^6.0",
         "guzzlehttp/guzzle": "~6.0"
-
     },
     "require-dev": {
+        "orchestra/testbench": "^3.8|^4.0|^5.0",
         "phpunit/phpunit": "^8.0",
         "vlucas/phpdotenv": "^3.0"
     },

--- a/config/geocoder.php
+++ b/config/geocoder.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-
     /*
      * The api key used when sending Geocoding requests to Google.
      */
@@ -36,4 +35,32 @@ return [
      */
     'country' => '',
 
+    /** Cache */
+    'cache' => [
+        /*
+         * By default looking caching is disabled, you may enable it to speed up performance and reduce api hits.
+         * Default: false
+         */
+        'enabled' => false,
+
+        /*
+         * By default lookups are cached for 24 hours to speed up performance and reduce api hits.
+         * Default: 24 hours ( 60 seconds * 60 minutes * 24 hours), 86400
+         */
+        'expiry' => (60 * 60 * 24),
+
+        /*
+         * The cache prefix key used to prefix stored lookups.
+         * Default: _geocoder:
+         */
+        'prefix' => '_geocoder:',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for Geocoder caching
+         * using any of the `store` drivers listed in the cache.php config file.
+         * Using null here means to use the `default` set in cache.php.
+         * Default: null
+         */
+        'driver' => null,
+    ],
 ];

--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -108,7 +108,7 @@ class Geocoder
 
     public function getCoordinatesForAddressCached(string $address): array
     {
-        return cache()->driver($this->cacheDriver)->remember($this->cachePrefix . md5($address), $this->cacheExpiry, function () use ($address) {
+        return cache()->driver($this->cacheDriver)->remember($this->cachePrefix.md5($address), $this->cacheExpiry, function () use ($address) {
             return $this->getCoordinatesForAddressUncached($address);
         });
     }
@@ -129,11 +129,11 @@ class Geocoder
 
         $geocodingResponse = json_decode($response->getBody());
 
-        if (!empty($geocodingResponse->error_message)) {
+        if (! empty($geocodingResponse->error_message)) {
             throw CouldNotGeocode::serviceReturnedError($geocodingResponse->error_message);
         }
 
-        if (!count($geocodingResponse->results)) {
+        if (! count($geocodingResponse->results)) {
             return $this->emptyResponse();
         }
 
@@ -151,7 +151,7 @@ class Geocoder
 
     public function getAddressForCoordinatesCached(float $lat, float $lng): array
     {
-        return cache()->driver($this->cacheDriver)->remember($this->cachePrefix . md5("{$lat}:{$lng}"), $this->cacheExpiry, function () use ($lat, $lng) {
+        return cache()->driver($this->cacheDriver)->remember($this->cachePrefix.md5("{$lat}:{$lng}"), $this->cacheExpiry, function () use ($lat, $lng) {
             return $this->getAddressForCoordinatesUncached($lat, $lng);
         });
     }
@@ -170,11 +170,11 @@ class Geocoder
 
         $reverseGeocodingResponse = json_decode($response->getBody());
 
-        if (!empty($reverseGeocodingResponse->error_message)) {
+        if (! empty($reverseGeocodingResponse->error_message)) {
             throw CouldNotGeocode::serviceReturnedError($reverseGeocodingResponse->error_message);
         }
 
-        if (!count($reverseGeocodingResponse->results)) {
+        if (! count($reverseGeocodingResponse->results)) {
             return $this->emptyResponse();
         }
 
@@ -206,7 +206,7 @@ class Geocoder
         if ($this->country) {
             $parameters = array_merge(
                 $parameters,
-                ['components' => 'country:' . $this->country]
+                ['components' => 'country:'.$this->country]
             );
         }
 

--- a/src/GeocoderServiceProvider.php
+++ b/src/GeocoderServiceProvider.php
@@ -10,13 +10,13 @@ class GeocoderServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__.'/../config/geocoder.php' => config_path('geocoder.php'),
+            __DIR__ . '/../config/geocoder.php' => config_path('geocoder.php'),
         ], 'config');
     }
 
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/geocoder.php', 'geocoder');
+        $this->mergeConfigFrom(__DIR__ . '/../config/geocoder.php', 'geocoder');
 
         $this->app->bind('geocoder', function ($app) {
             $client = app(Client::class);
@@ -26,7 +26,13 @@ class GeocoderServiceProvider extends ServiceProvider
                 ->setLanguage(config('geocoder.language'))
                 ->setRegion(config('geocoder.region'))
                 ->setBounds(config('geocoder.bounds'))
-                ->setCountry(config('geocoder.country'));
+                ->setCountry(config('geocoder.country'))
+                ->setCache(
+                    config('geocoder.cache.enabled'),
+                    config('geocoder.cache.expiry'),
+                    config('geocoder.cache.prefix'),
+                    config('geocoder.cache.driver')
+                );
         });
     }
 }

--- a/src/GeocoderServiceProvider.php
+++ b/src/GeocoderServiceProvider.php
@@ -10,13 +10,13 @@ class GeocoderServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__ . '/../config/geocoder.php' => config_path('geocoder.php'),
+            __DIR__.'/../config/geocoder.php' => config_path('geocoder.php'),
         ], 'config');
     }
 
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__ . '/../config/geocoder.php', 'geocoder');
+        $this->mergeConfigFrom(__DIR__.'/../config/geocoder.php', 'geocoder');
 
         $this->app->bind('geocoder', function ($app) {
             $client = app(Client::class);

--- a/tests/GeocoderTest.php
+++ b/tests/GeocoderTest.php
@@ -20,7 +20,7 @@ class GeocoderTest extends TestCase
 
         $apiKey = env('GOOGLE_API_KEY');
 
-        if (! $apiKey) {
+        if (!$apiKey) {
             $this->markTestSkipped('No Google API key was provided.');
 
             return;
@@ -105,6 +105,34 @@ class GeocoderTest extends TestCase
             ->getCoordinatesForAddress('Winnetka');
 
         $this->assertEquals('Winnetka, Los Angeles, CA, USA', $results['formatted_address']);
+    }
+
+    /** @test */
+    public function it_can_cache_address_lookup()
+    {
+        // Run initial lookup and cache the results.
+        $result = $this->geocoder->getCoordinatesForAddressCached('279 Bedford Ave, Brooklyn, NY 11211, USA');
+
+        $this->assertEquals('279 Bedford Ave, Brooklyn, NY 11211, USA', $result['formatted_address']);
+
+        // Get result directly from cache.
+        $result = cache()->driver(config('geocoder.cache.driver'))->get('_geocoder:' . md5('279 Bedford Ave, Brooklyn, NY 11211, USA'));
+
+        $this->assertEquals('279 Bedford Ave, Brooklyn, NY 11211, USA', $result['formatted_address']);
+    }
+
+    /** @test */
+    public function it_can_cache_coordinates_lookup()
+    {
+        // Run initial lookup and cache the results.
+        $result = $this->geocoder->getAddressForCoordinatesCached(40.714224, -73.961452);
+
+        $this->assertEquals('279 Bedford Ave, Brooklyn, NY 11211, USA', $result['formatted_address']);
+
+        // Get result directly from cache.
+        $result = cache()->driver(config('geocoder.cache.driver'))->get('_geocoder:' . md5('40.714224:-73.961452'));
+
+        $this->assertEquals('279 Bedford Ave, Brooklyn, NY 11211, USA', $result['formatted_address']);
     }
 
     protected function emptyResponse(): array

--- a/tests/GeocoderTest.php
+++ b/tests/GeocoderTest.php
@@ -20,7 +20,7 @@ class GeocoderTest extends TestCase
 
         $apiKey = env('GOOGLE_API_KEY');
 
-        if (!$apiKey) {
+        if (! $apiKey) {
             $this->markTestSkipped('No Google API key was provided.');
 
             return;
@@ -116,7 +116,7 @@ class GeocoderTest extends TestCase
         $this->assertEquals('279 Bedford Ave, Brooklyn, NY 11211, USA', $result['formatted_address']);
 
         // Get result directly from cache.
-        $result = cache()->driver(config('geocoder.cache.driver'))->get('_geocoder:' . md5('279 Bedford Ave, Brooklyn, NY 11211, USA'));
+        $result = cache()->driver(config('geocoder.cache.driver'))->get('_geocoder:'.md5('279 Bedford Ave, Brooklyn, NY 11211, USA'));
 
         $this->assertEquals('279 Bedford Ave, Brooklyn, NY 11211, USA', $result['formatted_address']);
     }
@@ -130,7 +130,7 @@ class GeocoderTest extends TestCase
         $this->assertEquals('279 Bedford Ave, Brooklyn, NY 11211, USA', $result['formatted_address']);
 
         // Get result directly from cache.
-        $result = cache()->driver(config('geocoder.cache.driver'))->get('_geocoder:' . md5('40.714224:-73.961452'));
+        $result = cache()->driver(config('geocoder.cache.driver'))->get('_geocoder:'.md5('40.714224:-73.961452'));
 
         $this->assertEquals('279 Bedford Ave, Brooklyn, NY 11211, USA', $result['formatted_address']);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,7 +16,7 @@ class TestCase extends Orchestra
 
     protected function loadEnvironmentVariables()
     {
-        if (!file_exists(__DIR__.'/../.env')) {
+        if (! file_exists(__DIR__.'/../.env')) {
             return;
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,11 +16,11 @@ class TestCase extends Orchestra
 
     protected function loadEnvironmentVariables()
     {
-        if (!file_exists(__DIR__ . '/../.env')) {
+        if (!file_exists(__DIR__.'/../.env')) {
             return;
         }
 
-        $dotenv = Dotenv::create(__DIR__ . '/..');
+        $dotenv = Dotenv::create(__DIR__.'/..');
 
         $dotenv->load();
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,9 +3,9 @@
 namespace Spatie\Geocoder\Tests;
 
 use Dotenv\Dotenv;
-use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Orchestra\Testbench\TestCase as Orchestra;
 
-class TestCase extends PHPUnitTestCase
+class TestCase extends Orchestra
 {
     protected function setUp(): void
     {
@@ -16,12 +16,28 @@ class TestCase extends PHPUnitTestCase
 
     protected function loadEnvironmentVariables()
     {
-        if (! file_exists(__DIR__.'/../.env')) {
+        if (!file_exists(__DIR__ . '/../.env')) {
             return;
         }
 
-        $dotenv = new Dotenv(__DIR__.'/..');
+        $dotenv = Dotenv::create(__DIR__ . '/..');
 
         $dotenv->load();
+    }
+
+    /**
+     * Set up the environment.
+     *
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('cache.default', 'array');
+        $app['config']->set('cache.prefix', 'spatie_tests---');
+
+        $app['config']->set('geocoder.cache.enabled', false);
+        $app['config']->set('geocoder.cache.expiry', 86400);
+        $app['config']->set('geocoder.cache.prefix', '_geocoder:');
+        $app['config']->set('geocoder.cache.driver', 'array');
     }
 }


### PR DESCRIPTION
Hi @freekmurze,

I've never submitted a pull request before, hopefully I have done everything correctly.

This pull request aims to add some caching functionality into Geocoder.

By default caching isn't "enabled/enforced" but can be used anytime via the getCoordinatesForAddressCached and getAddressForCoordinatesCached methods.

For when caching is "enabled/enforced" you can also use the following getCoordinatesForAddressUncached and getAddressForCoordinatesUncached methods to bypass caching.

I also had to change the tests loadEnvironmentVariables method to call Dotenv::create 
(I was unable to run tests without doing this)

Thanks.