### PR TITLE
Fix typo in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ $geocoder = new Geocoder($client);
 
 $geocoder->setApiKey(config('geocoder.key'));
 
-$geocoder->setCountry(config('US'));
+$geocoder->setCountry(config('geocoder.country', 'US'));
 
 $geocoder->getCoordinatesForAddress('Infinite Loop 1, Cupertino');
 


### PR DESCRIPTION
Before it got an incorrect value from config.
Keeps same value as default.