### PR TITLE
return multiple results for reverse-geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,49 @@ $geocoder->getAddressForCoordinates(40.714224, -73.961452);
 */
 ```
 
+You can also reverse geocode coordinates to all the related addresses.
+
+```php
+$geocoder->getAllAddressesForCoordinates(40.714224, -73.961452);
+
+/*
+  This function returns an array of results (array of array)
+  array:2 [
+    0 => array: 7 [
+      "lat" => 40.7142205
+      "lng" => -73.9612903
+      "accuracy" => "ROOFTOP"
+      "formatted_address" => "277 Bedford Ave, Brooklyn, NY 11211, USA",
+      "viewport" => [
+        "northeast" => [
+          "lat" => 37.3330546802915,
+          "lng" => -122.0294342197085
+        ],
+        "southwest" => [
+          "lat" => 37.3303567197085,
+          "lng" => -122.0321321802915
+        ]
+      ]
+    ],
+    1 => array: 7 [
+      "lat" => 40.7142015
+      "lng" => -73.9613077
+      "accuracy" => "ROOFTOP"
+      "formatted_address" => "279 Bedford Ave, Brooklyn, NY 11211, USA",
+      "viewport" => [
+        "northeast" => [
+          "lat" => 40.715557080291,
+          "lng" => -73.959947169708
+        ],
+        "southwest" => [
+          "lat" => 40.712859119708,
+          "lng" => -73.962645130291
+        ]
+      ]
+    ]
+  ]
+*/
+```
 
 If you are using the package with Laravel, you can simply call `getCoordinatesForAddress`.
 

--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -72,28 +72,9 @@ class Geocoder
 
     public function getCoordinatesForAddress(string $address): array
     {
-        if (empty($address)) {
-            return $this->emptySingleResponse();
-        }
+        $response = $this->getAllCoordinatesForAddress($address);
 
-        $payload = $this->getRequestPayload(compact('address'));
-        $response = $this->client->request('GET', $this->endpoint, $payload);
-
-        if ($response->getStatusCode() !== 200) {
-            throw CouldNotGeocode::couldNotConnect();
-        }
-
-        $geocodingResponse = json_decode($response->getBody());
-
-        if (! empty($geocodingResponse->error_message)) {
-            throw CouldNotGeocode::serviceReturnedError($geocodingResponse->error_message);
-        }
-
-        if (! count($geocodingResponse->results)) {
-            return $this->emptySingleResponse();
-        }
-
-        return $this->formatResponse($geocodingResponse)[0];
+        return $response[0];
     }
 
     public function getAllCoordinatesForAddress(string $address): array
@@ -124,6 +105,13 @@ class Geocoder
 
     public function getAddressForCoordinates(float $lat, float $lng): array
     {
+        $response = $this->getAllAddressesForCoordinates($lat, $lng);
+
+        return $response[0];
+    }
+
+    public function getAllAddressesForCoordinates(float $lat, float $lng): array
+    {
         $payload = $this->getRequestPayload([
             'latlng' => "$lat,$lng",
         ]);
@@ -136,10 +124,10 @@ class Geocoder
             throw CouldNotGeocode::serviceReturnedError($reverseGeocodingResponse->error_message);
         }
         if (! count($reverseGeocodingResponse->results)) {
-            return $this->emptySingleResponse();
+            return $this->emptyResponse();
         }
 
-        return $this->formatResponse($reverseGeocodingResponse)[0];
+        return $this->formatResponse($reverseGeocodingResponse);
     }
 
     protected function formatResponse($response): array
@@ -188,17 +176,6 @@ class Geocoder
                 'formatted_address' => static::RESULT_NOT_FOUND,
                 'viewport' => static::RESULT_NOT_FOUND,
             ],
-        ];
-    }
-
-    protected function emptySingleResponse(): array
-    {
-        return [
-            'lat' => 0,
-            'lng' => 0,
-            'accuracy' => static::RESULT_NOT_FOUND,
-            'formatted_address' => static::RESULT_NOT_FOUND,
-            'viewport' => static::RESULT_NOT_FOUND,
         ];
     }
 }

--- a/tests/GeocoderTest.php
+++ b/tests/GeocoderTest.php
@@ -98,6 +98,25 @@ class GeocoderTest extends TestCase
     }
 
     /** @test */
+    public function it_can_translate_coordinates_to_multiple_addresses()
+    {
+        $results = $this->geocoder->getAllAddressesForCoordinates(40.714224, -73.961452);
+
+        $this->assertIsArray($results);
+        $this->assertIsArray($results[0]);
+
+        $result = $results[0];
+
+        $this->assertEquals('277 Bedford Ave, Brooklyn, NY 11211, USA', $result['formatted_address']);
+
+        $result = $this->geocoder
+            ->setLanguage('nl')
+            ->getAddressForCoordinates(40.714224, -73.961452);
+
+        $this->assertEquals('277 Bedford Ave, Brooklyn, NY 11211, Verenigde Staten', $result['formatted_address']);
+    }
+
+    /** @test */
     public function it_can_include_the_address_components_in_a_response()
     {
         $results = $this->geocoder->getCoordinatesForAddress('Infinite Loop 1, Cupertino');


### PR DESCRIPTION
Hello there,

I made a little contribution for this package because, currently, `geocoding` can have either multiple results and a single result whereas `reverse-geocoding` can have a single result only. In my use-case, I needed multiple results for reverse-geocoding as well. So, I add a method called `getAllAddressesForCoordinates`

- this PR didn't introduce any kinda break changes.
- removed some duplicate codes.
- included README.md and a test method.

Hope this PR fully followed your contributing guidelines.
Thank you.

Chuck