### PR TITLE
Add ability to resolve Geocoder from the fully qualified class name

### DIFF
--- a/src/GeocoderServiceProvider.php
+++ b/src/GeocoderServiceProvider.php
@@ -28,5 +28,7 @@ class GeocoderServiceProvider extends ServiceProvider
                 ->setBounds(config('geocoder.bounds'))
                 ->setCountry(config('geocoder.country'));
         });
+
+        $this->app->bind(Geocoder::class, 'geocoder');
     }
 }

--- a/tests/GeocoderTest.php
+++ b/tests/GeocoderTest.php
@@ -152,6 +152,26 @@ class GeocoderTest extends TestCase
         $this->assertArrayHasKey('place_id', $results);
     }
 
+    /** @test */
+    public function it_can_be_resolved_from_the_container_with_the_alias()
+    {
+        config()->set('geocoder.key', $this->getApiKey());
+
+        $results = resolve('geocoder')->getCoordinatesForAddress('Infinite Loop 1, Cupertino');
+
+        $this->assertArrayHasKey('place_id', $results);
+    }
+
+    /** @test */
+    public function it_can_be_resolved_from_the_container_with_the_full_class_name()
+    {
+        config()->set('geocoder.key', $this->getApiKey());
+
+        $results = resolve(Geocoder::class)->getCoordinatesForAddress('Infinite Loop 1, Cupertino');
+
+        $this->assertArrayHasKey('place_id', $results);
+    }
+
     protected function emptyResponse(): array
     {
         return [


### PR DESCRIPTION
I've added a binding to the Service Provider using the fully qualified class name rather than just the `geocoder` alias, this enables the Geocoder class to be automatically injected by Laravel, either through controller dependency injection or using the `resolve()` helper function or equivalents.

I've also added a couple of tests just to prove that resolving the class via the alias and via the FQCN both work.