### PR TITLE
Update formatResponse to include partial_match

### DIFF
--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -140,6 +140,7 @@ class Geocoder
                 'formatted_address' => $result->formatted_address,
                 'viewport' => $result->geometry->viewport,
                 'address_components' => $result->address_components,
+                'partial_match' => $result->partial_match,
                 'place_id' => $result->place_id,
             ];
         }, $response->results);


### PR DESCRIPTION
The Google API returns wether the result is a partial_match (potential misspelling in the search). This is usefull information to return with the result, and is already present in the $result variable. This change also adds the partial_match to the formatted result array.