### PR TITLE
Return types

### DIFF
--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -115,14 +115,19 @@ class Geocoder
         $payload = $this->getRequestPayload([
             'latlng' => "$lat,$lng",
         ]);
+        
         $response = $this->client->request('GET', $this->endpoint, $payload);
+        
         if ($response->getStatusCode() !== 200) {
             throw CouldNotGeocode::couldNotConnect();
         }
+        
         $reverseGeocodingResponse = json_decode($response->getBody());
+        
         if (! empty($reverseGeocodingResponse->error_message)) {
             throw CouldNotGeocode::serviceReturnedError($reverseGeocodingResponse->error_message);
         }
+        
         if (! count($reverseGeocodingResponse->results)) {
             return $this->emptyResponse();
         }
@@ -142,6 +147,7 @@ class Geocoder
                 'address_components' => $result->address_components,
                 'partial_match' => isset($result->partial_match) ? $result->partial_match : false ,
                 'place_id' => $result->place_id,
+                'types' => $result->types,
             ];
         }, $response->results);
 


### PR DESCRIPTION
We would like to return the types of the results for filtering.

Question: is is possible to add this to the query as well? Like `setLanguage()`, `setCountry()`? It would reduce the number of results to the actual types. Unfortunately I cannot find this in the Google Maps API?

Thanks